### PR TITLE
Wrap build output in IIFE

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
             input: "src/module.ts",
             output: {
                 entryFileNames: "module.js",
-                format: "es",
+                format: "iife",
             },
         },
     },


### PR DESCRIPTION
This prevents pollution to/from the global scope, avoiding conflicts with other modules.